### PR TITLE
Fix a bug where empty values couldn't be assigned to the string fields

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,11 +1,15 @@
 ---
-extends: airbnb
+extends:
+  - airbnb
+  - plugin:mocha/recommended
 env:
   node: true
   es6: true
 parserOptions:
   sourceType: module
-  ecmaVersion: 6
+  ecmaVersion: 2018
+plugins:
+  - mocha
 globals:
   describe: true
   it: true
@@ -13,18 +17,18 @@ globals:
   after: true
   afterEach: true
 rules:
-  max-len: [1, 220, 2, {"ignoreUrls":true}]
+  max-len: [1, 200, 2, {"ignoreUrls":true}]
   curly: [2, "multi-line"]
   comma-dangle: [0, always-multiline]
   no-underscore-dangle: 0
-  object-curly-newline: 0
-  no-plusplus: 0
   eqeqeq: [2, "allow-null"]
   global-require: 0
   no-shadow: 1
   no-param-reassign: [2, { "props": false }]
   indent: [2, 4, { "SwitchCase": 1 }]
   padded-blocks: [2, { "switches": "always", "classes": "always" }]
+  import/no-extraneous-dependencies: ["error", { devDependencies: ['app/test/**']}]
+  mocha/no-mocha-arrows: 0
   quotes:
     - 2
     - single

--- a/app/src/services/metadata.service.js
+++ b/app/src/services/metadata.service.js
@@ -1,4 +1,5 @@
 const logger = require('logger');
+const isNil = require('lodash/isNil');
 const Metadata = require('models/metadata.model');
 const MetadataNotFound = require('errors/metadataNotFound.error');
 const MetadataDuplicated = require('errors/metadataDuplicated.error');
@@ -102,14 +103,12 @@ class MetadataService {
             throw new MetadataNotFound(`Metadata of resource ${resource.type}: ${resource.id} doesn't exist`);
         }
 
-        const hasValue = value => value !== undefined && value !== null;
-
         logger.debug('Updating metadata');
         metadata.name = body.name ? body.name : metadata.name;
-        metadata.description = hasValue(body.description) ? body.description : metadata.description;
-        metadata.source = hasValue(body.source) ? body.source : metadata.source;
-        metadata.citation = hasValue(body.citation) ? body.citation : metadata.citation;
-        metadata.license = hasValue(body.license) ? body.license : metadata.license;
+        metadata.description = !isNil(body.description) ? body.description : metadata.description;
+        metadata.source = !isNil(body.source) ? body.source : metadata.source;
+        metadata.citation = !isNil(body.citation) ? body.citation : metadata.citation;
+        metadata.license = !isNil(body.license) ? body.license : metadata.license;
         metadata.info = body.info ? body.info : metadata.info;
         metadata.columns = body.columns ? body.columns : metadata.columns;
         metadata.applicationProperties = body.applicationProperties ? body.applicationProperties : metadata.applicationProperties;

--- a/app/src/services/metadata.service.js
+++ b/app/src/services/metadata.service.js
@@ -101,12 +101,15 @@ class MetadataService {
             logger.error('Error updating metadata');
             throw new MetadataNotFound(`Metadata of resource ${resource.type}: ${resource.id} doesn't exist`);
         }
+
+        const hasValue = value => value !== undefined && value !== null;
+
         logger.debug('Updating metadata');
         metadata.name = body.name ? body.name : metadata.name;
-        metadata.description = body.description ? body.description : metadata.description;
-        metadata.source = body.source ? body.source : metadata.source;
-        metadata.citation = body.citation ? body.citation : metadata.citation;
-        metadata.license = body.license ? body.license : metadata.license;
+        metadata.description = hasValue(body.description) ? body.description : metadata.description;
+        metadata.source = hasValue(body.source) ? body.source : metadata.source;
+        metadata.citation = hasValue(body.citation) ? body.citation : metadata.citation;
+        metadata.license = hasValue(body.license) ? body.license : metadata.license;
         metadata.info = body.info ? body.info : metadata.info;
         metadata.columns = body.columns ? body.columns : metadata.columns;
         metadata.applicationProperties = body.applicationProperties ? body.applicationProperties : metadata.applicationProperties;

--- a/app/test/.eslintrc
+++ b/app/test/.eslintrc
@@ -1,2 +1,0 @@
-rules:
-  import/no-extraneous-dependencies: 0

--- a/app/test/e2e/dataset-clone.spec.js
+++ b/app/test/e2e/dataset-clone.spec.js
@@ -2,7 +2,9 @@ const Metadata = require('models/metadata.model');
 const nock = require('nock');
 const { ROLES } = require('./test.constants');
 const { getTestServer } = require('./test-server');
-const { validateMetadata, deserializeDataset, createMetadata, ensureCorrectError, initHelpers } = require('./utils');
+const {
+    validateMetadata, deserializeDataset, createMetadata, ensureCorrectError, initHelpers
+} = require('./utils');
 
 const requester = getTestServer();
 const prefix = '/api/v1/dataset';
@@ -10,7 +12,8 @@ const helpers = initHelpers(
     requester,
     `${prefix}/123/metadata/clone`,
     'post',
-    { newDataset: 'test123' });
+    { newDataset: 'test123' }
+);
 
 describe('DATASET CLONE endpint', () => {
     before(async () => {

--- a/app/test/e2e/layer-delete.spec.js
+++ b/app/test/e2e/layer-delete.spec.js
@@ -16,7 +16,8 @@ const helpers = initHelpers(
     `${prefix}/${DEFAULT.datasetID}/layer/${DEFAULT.widgetID}/metadata`,
     'delete',
     {},
-    '?language=en&application=rw');
+    '?language=en&application=rw'
+);
 
 describe('METADATA LAYER DELETE endpoint', () => {
     before(async () => {

--- a/app/test/e2e/layer-patch.spec.js
+++ b/app/test/e2e/layer-patch.spec.js
@@ -3,7 +3,9 @@ const nock = require('nock');
 const { ROLES } = require('./test.constants');
 const { getTestServer } = require('./test-server');
 const { createMetadataResourceForUpdate, WIDGET_WRONG_DATAS } = require('./test.constants');
-const { validateMetadata, ensureCorrectError, initHelpers, createMetadata } = require('./utils');
+const {
+    validateMetadata, ensureCorrectError, initHelpers, createMetadata
+} = require('./utils');
 
 const requester = getTestServer();
 const prefix = '/api/v1/dataset';
@@ -15,7 +17,8 @@ const helpers = initHelpers(
     requester,
     `${prefix}/${DEFAULT.datasetID}/layer/${DEFAULT.widgetID}/metadata`,
     'patch',
-    createMetadataResourceForUpdate('layer'));
+    createMetadataResourceForUpdate('layer')
+);
 
 const updateLayer = (data = createMetadataResourceForUpdate('layer'), datasetID = DEFAULT.datasetID) => requester
     .patch(`${prefix}/${datasetID}/layer/${data.resource.id}/metadata`)

--- a/app/test/e2e/layer-post.spec.js
+++ b/app/test/e2e/layer-post.spec.js
@@ -15,7 +15,8 @@ const helpers = initHelpers(
     requester,
     `${prefix}/${DEFAULT.datasetID}/layer/${DEFAULT.layerID}/metadata`,
     'post',
-    createMetadataResource('layer'));
+    createMetadataResource('layer')
+);
 
 const createLayer = (data = createMetadataResource('layer')) => {
     const { widgetID, datasetID } = DEFAULT;

--- a/app/test/e2e/metadata-find-by-ids.spec.js
+++ b/app/test/e2e/metadata-find-by-ids.spec.js
@@ -61,17 +61,6 @@ describe('Find metadatas by IDs', () => {
         response.body.should.have.property('data').and.be.an('array').and.length(0);
     });
 
-    it('Find metadatas with id list containing metadata that does not exist returns an empty list (empty db)', async () => {
-        const response = await requester
-            .post(`/api/v1/dataset/metadata/find-by-ids`)
-            .send({
-                ids: ['abcd']
-            });
-
-        response.status.should.equal(200);
-        response.body.should.have.property('data').and.be.an('array').and.length(0);
-    });
-
     it('Find metadatas with id list containing a metadata that exists returns only the listed metadata', async () => {
         metadataOne = await new Metadata(createMetadata()).save();
         metadataTwo = await new Metadata(createMetadata()).save();

--- a/app/test/e2e/utils.js
+++ b/app/test/e2e/utils.js
@@ -1,3 +1,4 @@
+const MetadataModel = require('models/metadata.model');
 const { ROLES } = require('./test.constants');
 
 function deserializeDataset(response) {
@@ -92,10 +93,13 @@ const createMetadata = (type) => {
     };
 };
 
+const createMetadataInDB = async () => (MetadataModel(createMetadata()).save());
+
 module.exports = {
     deserializeDataset,
     validateMetadata,
     createMetadata,
+    createMetadataInDB,
     initHelpers,
     getUUID,
     ensureCorrectError

--- a/app/test/e2e/widget-delete.spec.js
+++ b/app/test/e2e/widget-delete.spec.js
@@ -16,7 +16,8 @@ const helpers = initHelpers(
     `${prefix}/${DEFAULT.datasetID}/widget/${DEFAULT.widgetID}/metadata`,
     'delete',
     {},
-    '?language=en&application=rw');
+    '?language=en&application=rw'
+);
 
 describe('METADATA WIDGET DELETE endpoint', () => {
     before(async () => {

--- a/app/test/e2e/widget-patch.spec.js
+++ b/app/test/e2e/widget-patch.spec.js
@@ -3,7 +3,9 @@ const nock = require('nock');
 const { ROLES } = require('./test.constants');
 const { getTestServer } = require('./test-server');
 const { createMetadataResourceForUpdate, WIDGET_WRONG_DATAS } = require('./test.constants');
-const { validateMetadata, ensureCorrectError, initHelpers, createMetadata } = require('./utils');
+const {
+    validateMetadata, ensureCorrectError, initHelpers, createMetadata
+} = require('./utils');
 
 const requester = getTestServer();
 const prefix = '/api/v1/dataset';
@@ -15,7 +17,8 @@ const helpers = initHelpers(
     requester,
     `${prefix}/${DEFAULT.datasetID}/widget/${DEFAULT.widgetID}/metadata`,
     'patch',
-    createMetadataResourceForUpdate('widget'));
+    createMetadataResourceForUpdate('widget')
+);
 
 const updateWidget = (data = createMetadataResourceForUpdate('widget'), datasetID = DEFAULT.datasetID) => requester
     .patch(`${prefix}/${datasetID}/widget/${data.resource.id}/metadata`)

--- a/app/test/e2e/widget-post.spec.js
+++ b/app/test/e2e/widget-post.spec.js
@@ -15,7 +15,8 @@ const helpers = initHelpers(
     requester,
     `${prefix}/${DEFAULT.datasetID}/widget/${DEFAULT.widgetID}/metadata`,
     'post',
-    createMetadataResource('widget'));
+    createMetadataResource('widget')
+);
 
 const createWidget = (data = createMetadataResource('widget')) => {
     const { widgetID, datasetID } = DEFAULT;

--- a/package-lock.json
+++ b/package-lock.json
@@ -574,17 +574,17 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chai": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
-      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "check-error": "^1.0.1",
-        "deep-eql": "^3.0.0",
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
         "get-func-name": "^2.0.0",
-        "pathval": "^1.0.0",
-        "type-detect": "^4.0.0"
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
       }
     },
     "chai-datetime": {
@@ -1650,6 +1650,15 @@
         "emoji-regex": "^7.0.2",
         "has": "^1.0.3",
         "jsx-ast-utils": "^2.2.1"
+      }
+    },
+    "eslint-plugin-mocha": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-6.2.0.tgz",
+      "integrity": "sha512-vE/+tHJVom2BkMOiwkOKcAM5YqGPk3C6gMvQ32DHihKkaXF6vmxtj3UEOg64wP3m8/Zk5V/UmQbFE5nqu1EXSg==",
+      "dev": true,
+      "requires": {
+        "ramda": "^0.26.1"
       }
     },
     "eslint-plugin-react": {
@@ -5769,6 +5778,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "ramda": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
+      "dev": true
     },
     "raw-body": {
       "version": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -51,12 +51,14 @@
     "sd-ct-register-microservice-node": "^2.1.7"
   },
   "devDependencies": {
+    "chai": "^4.2.0",
     "chai-datetime": "^1.5.0",
     "chai-http": "^4.3.0",
     "eslint": "^6.5.1",
     "eslint-config-airbnb": "^17.1.1",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-mocha": "^6.2.0",
     "eslint-plugin-react": "^7.16.0",
     "grunt": "^1.0.4",
     "grunt-cli": "^1.3.2",


### PR DESCRIPTION
This PR fixes a bug where it would be impossible to assign empty values (`''`) to the string fields of a metadata object, when updating it.

## Testing instructions

A regression test has been written for this bug. Run `./metadata.sh test` to test the changes.

## Pivotal tracker

Not tracked.